### PR TITLE
changed path of cytoscape.js dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "angular-cookies": "1.2.6",
     "angular-sanitize": "1.2.6",
     "angular-route": "1.2.6",
-    "cytoscape.js": "git@github.com:cytoscape/cytoscape.js.git#~2.0.4"
+    "cytoscape.js": "https://github.com/cytoscape/cytoscape.js.git#~2.0.4"
   },
   "devDependencies": {
     "angular-mocks": "1.2.6",


### PR DESCRIPTION
I tried with the current configuration and got the following error on bower install command:

```
bower cytoscape.js#~2.0.4             ECMDERR Failed to execute "git ls-remote --tags --heads git@github.com:cytoscape/cytoscape.js.git", exit code of #128
```
